### PR TITLE
Fix/add missing actions type

### DIFF
--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -106,7 +106,7 @@ export interface FirecrawlDocument<T = any, ActionsSchema extends (ActionsResult
  * Parameters for scraping operations.
  * Defines the options and configurations available for scraping web content.
  */
-export interface CrawlScrapeOptions {
+export interface CrawlScrapeOptions<ActionsSchema extends (Action[] | undefined) = undefined> {
   formats?: ("markdown" | "html" | "rawHtml" | "content" | "links" | "screenshot" | "screenshot@fullPage" | "extract" | "json" | "changeTracking")[];
   headers?: Record<string, string>;
   includeTags?: string[];
@@ -126,6 +126,7 @@ export interface CrawlScrapeOptions {
   storeInCache?: boolean;
   maxAge?: number;
   parsePDF?: boolean;
+  actions?: ActionsSchema[];
 }
 
 export type Action = {
@@ -157,7 +158,7 @@ export type Action = {
   script: string,
 };
 
-export interface ScrapeParams<LLMSchema extends zt.ZodSchema = any, ActionsSchema extends (Action[] | undefined) = undefined> extends CrawlScrapeOptions {
+export interface ScrapeParams<LLMSchema extends zt.ZodSchema = any> extends CrawlScrapeOptions {
   extract?: {
     prompt?: string;
     schema?: LLMSchema;
@@ -174,7 +175,6 @@ export interface ScrapeParams<LLMSchema extends zt.ZodSchema = any, ActionsSchem
     modes?: ("json" | "git-diff")[];
     tag?: string | null;
   }
-  actions?: ActionsSchema;
   agent?: AgentOptions;
   zeroDataRetention?: boolean;
 }

--- a/apps/js-sdk/firecrawl/src/index.ts
+++ b/apps/js-sdk/firecrawl/src/index.ts
@@ -618,7 +618,7 @@ export default class FirecrawlApp {
    */
   async scrapeUrl<T extends zt.ZodSchema, ActionsSchema extends (Action[] | undefined) = undefined>(
     url: string,
-    params?: ScrapeParams<T, ActionsSchema>
+    params?: ScrapeParams<T>
   ): Promise<ScrapeResponse<zt.infer<T>, ActionsSchema extends Action[] ? ActionsResult : never> | ErrorResponse> {
     const headers: AxiosRequestHeaders = {
       "Content-Type": "application/json",


### PR DESCRIPTION
## Description
- API docs show `actions` in the `scrapeOptions` when creating a crawl, but it's missing from the js sdk.
- This PR move the `actions` (and its `ActionSchema`) up from `ScrapeParams` to `CrawlScrapeOptions`

## Tests
- Tested locally using patch-package in our own project.